### PR TITLE
Add a simple executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .svn
+/node_modules
+.DS_Store
+.swp
+.log

--- a/README.md
+++ b/README.md
@@ -56,3 +56,8 @@ var f = cajaVM.compileExpr("console.log('hi')");
 f({console: console});
 ```
 
+Included is a binary runner under the name `ses`
+
+```bash
+ses example/code.js
+```

--- a/bin/ses
+++ b/bin/ses
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+//
+var usage = "usage:\n  ses --bootstrap=myenv.js code.js bootstrapFnArgs1 bootstrapFnArgs2"
+
+var FS = require("fs");
+var PATH = require("path");
+var VM = require("vm");
+var argv = require("optimist").argv;
+
+var source = FS.readFileSync(PATH.join(__dirname, "../initSES.js"));
+var script = new VM.Script(source);
+script.runInThisContext();
+
+var bootstrapFile = argv.b || argv.bootstrap;
+var bootstrapArgs = argv._ && argv._.slice(1);
+
+var codeFile = argv._[0];
+if (!codeFile) {
+  console.error(usage);
+  process.exit(1);
+}
+var code = FS.readFileSync(PATH.resolve(process.cwd(), codeFile));
+
+var runner = cajaVM.compileExpr(code);
+var runnerEnv = bootstrapFile && require(PATH.resolve(process.cwd(), bootstrapFile)).apply(null, bootstrapArgs) || {console:console};
+runner(runnerEnv);
+

--- a/example/code.js
+++ b/example/code.js
@@ -1,0 +1,1 @@
+console.log("HI")

--- a/package.json
+++ b/package.json
@@ -2,5 +2,10 @@
     "name": "ses",
     "version": "0.0.0",
     "dependencies": {
+      "optimist": "~0.3.5"      
+    },
+    "preferGlobal": true,
+    "bin": {
+      "ses": "bin/ses"
     }
 }


### PR DESCRIPTION
Needed a sane way to invoke a bootstrap for the environment from the cli for my sanity.

`npm -g i` to install it or run from `bin/ses`

``` bash
ses code.js #defaults to just a `console` global available
# see --bootstrap to set custom env
```
